### PR TITLE
Always attach to "pre_get_posts" hook.

### DIFF
--- a/wp-disable-posts.php
+++ b/wp-disable-posts.php
@@ -25,10 +25,8 @@ class WP_Disable_Posts
 			/* need to return a 404 when post_type `post` objects are found */
 			add_action( 'posts_results', array( __CLASS__, 'check_post_type' ) );
 
-			if ( is_search() ) {
-				/* do not return any instances of post_type `post` */
-				add_filter( 'pre_get_posts', array( __CLASS__, 'remove_from_search_filter' ) );
-			}
+			/* do not return any instances of post_type `post` */
+			add_filter( 'pre_get_posts', array( __CLASS__, 'remove_from_search_filter' ) );
 		}
 	}
 


### PR DESCRIPTION
You can't use is_search when adding filters because that can only be used after the `posts_selection` hooks (according to [Conditional Tags in the Codex](https://codex.wordpress.org/Conditional_Tags)).

I'm really very new to WordPress and plug-ins, but I believe it does not hurt to just always hook to the `pre_get_posts` and remove posts anyway.
