### PR TITLE
improve post type comparison logic

### DIFF
--- a/wp-disable-posts.php
+++ b/wp-disable-posts.php
@@ -145,11 +145,11 @@ class WP_Disable_Posts
 	{
 		$query_post_types = is_array($query->query['post_type']) ? $query->query['post_type'] : (array) $query->query['post_type'];
 
-		if ( array_key_exists('post', $post_types) ) {
+		if ( array_key_exists('post', $query_post_types) ) {
 			/* exclude post_type `post` from the query results */
-			unset( $post_types['post'] );
+			unset( $query_post_types['post'] );
 		}
-		$query->set( 'post_type', array_values($post_types) );
+		$query->set( 'post_type', array_values($query_post_types) );
 
 		return $query;
 	}

--- a/wp-disable-posts.php
+++ b/wp-disable-posts.php
@@ -143,7 +143,7 @@ class WP_Disable_Posts
 	 */
 	public static function remove_from_search_filter( $query )
 	{
-		$post_types = get_post_types();
+		$query_post_types = is_array($query->query['post_type']) ? $query->query['post_type'] : (array) $query->query['post_type'];
 
 		if ( array_key_exists('post', $post_types) ) {
 			/* exclude post_type `post` from the query results */


### PR DESCRIPTION
I ran into a problem while querying custom post types.  Although my WP_Query object was showing that the only 'post_type' being passed was 'network', I was getting ALL of my registered 'post_type's returned.  So, I started to poke around and found that every time there is a query, wp-disable-posts resets the query's 'post_type' to everything except 'post', "undoing the work" of the original query's 'post_type' parameter.

By using the original query's 'post_type' parameter, we avoid resetting the 'post_type' to all _queried_ 'post_type's except 'post'.
